### PR TITLE
Add support for events

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,7 @@ As you may have guessed, they are also supported. See [examples/events.py](examp
 
 
 ## Full fledged example
-If you wanna see the full dance, go ahead and look [examples/full.py](examples/full.py) for an example
-of all available functionality including
+If you wanna see the full dance, go ahead and look [examples/full.py](examples/full.py) for an example of all available functionality including
 - A register command that opens a modal
 - A hello command that shows interactive buttons
 - A shortcut to roll a dice and get a random number

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Flask-Slack
-`Flask-Slack` is a framework to accelerate your development of slack apps by letting you focus on **what you want** instead of fighting with *how to do it*
+`Flask-Slack` is a light framework designed to accelerate your development of slack apps by letting you focus on **what you want** instead of fighting with *how to do it*
 
 ## Quickstart
 ```python
@@ -41,10 +41,20 @@ Of course! See [examples/views.py](examples/views.py) for a quick example
 
 ### Are interactive actions supported?
 Yes! See [examples/actions.py](examples/actions.py) for a quickstart.
-
 >Note: Legacy actions are unsupported by design as they are discouraged by slack. Nevertheless, if there's popular demand, we could add support for them.
 
+### And slack events?
+As you may have guessed, they are also supported. See [examples/events.py](examples/events.py) for an example.
+
+
+## Full fledged example
+If you wanna see the full dance, go ahead and look [examples/full.py](examples/full.py) for an example
+of all available functionality including
+- A register command that opens a modal
+- A hello command that shows interactive buttons
+- A shortcut to roll a dice and get a random number
+- An event handler that echoes reactions to messages.
+
 ## Roadmap
-1. Support for slack events through [slackeventsapi](https://github.com/slackapi/python-slack-events-api)
-2. Support for app factory pattern
-3. Support for blueprints
+1. Support for app factory pattern
+2. Support for blueprints

--- a/examples/events.py
+++ b/examples/events.py
@@ -8,14 +8,14 @@ slack = Slack(os.environ["SLACK_BOT_TOKEN"])
 
 @app.event("message")
 def handle_message(payload):
-    """Listen to message events and react with python emoji
+    """Listen to messages containing `python` and react with python emoji
 
     Note:
-        *ALL* event handlers will receive a payload positional argument with the event info.
+        Your event handler function *MUST* accept a positional argument with the event payload
 
     Preconditions:
-        - Setup event subscription https://api.slack.com/events-api
-        - Suscribe to `message.channels` events so your app gets notified
+        - Setup event subscription https://api.slack.com/events-api and point to `/slack/events` uri
+        - Suscribe to `message.channels` events so your app gets notified of this event
     """
     event = payload["event"]
     if event.get("subtype") is None and 'python' in event.get('text', ''):

--- a/examples/events.py
+++ b/examples/events.py
@@ -1,0 +1,41 @@
+from slackeventsapi import SlackEventAdapter
+import os
+from flask_slack import Flack, Slack
+
+
+app = Flack(__name__)
+
+events = SlackEventAdapter(os.environ["SLACK_SIGNING_SECRET"], "/slack/events", app)
+slack_client = Slack(os.environ["SLACK_BOT_TOKEN"])
+
+
+@events.on("message")
+def handle_message(event_data):
+    """Listen to message events and react with python emoji
+
+    Preconditions:
+        - Setup event subscription https://api.slack.com/events-api
+        - Suscribe to `message.channels` events so your app gets notified
+    """
+    event = event_data["event"]
+    # If the incoming message contains "hi", then respond with a "Hello" message
+    if event.get("subtype") is None and 'python' in event.get('text', ''):
+        channel = event["channel"]
+        timestamp = event['ts']
+        slack_client.reactions_add(name='snake', channel=channel, timestamp=timestamp)
+
+
+@events.on("message")
+def handle_message2(event_data):
+    """Listen to message events and react with python emoji
+
+    Preconditions:
+        - Setup event subscription https://api.slack.com/events-api
+        - Suscribe to `message.channels` events so your app gets notified
+    """
+    event = event_data["event"]
+    # If the incoming message contains "hi", then respond with a "Hello" message
+    if event.get("subtype") is None and 'python' in event.get('text', ''):
+        channel = event["channel"]
+        timestamp = event['ts']
+        slack_client.reactions_add(name='thumbsup', channel=channel, timestamp=timestamp)

--- a/examples/events.py
+++ b/examples/events.py
@@ -1,41 +1,26 @@
-from slackeventsapi import SlackEventAdapter
 import os
 from flask_slack import Flack, Slack
 
-
 app = Flack(__name__)
 
-events = SlackEventAdapter(os.environ["SLACK_SIGNING_SECRET"], "/slack/events", app)
-slack_client = Slack(os.environ["SLACK_BOT_TOKEN"])
+slack = Slack(os.environ["SLACK_BOT_TOKEN"])
 
 
-@events.on("message")
-def handle_message(event_data):
+@app.event("message")
+def handle_message(payload):
     """Listen to message events and react with python emoji
+
+    Note:
+        *ALL* event handlers will receive a payload positional argument with the event info.
 
     Preconditions:
         - Setup event subscription https://api.slack.com/events-api
         - Suscribe to `message.channels` events so your app gets notified
     """
-    event = event_data["event"]
-    # If the incoming message contains "hi", then respond with a "Hello" message
+    event = payload["event"]
     if event.get("subtype") is None and 'python' in event.get('text', ''):
-        channel = event["channel"]
-        timestamp = event['ts']
-        slack_client.reactions_add(name='snake', channel=channel, timestamp=timestamp)
-
-
-@events.on("message")
-def handle_message2(event_data):
-    """Listen to message events and react with python emoji
-
-    Preconditions:
-        - Setup event subscription https://api.slack.com/events-api
-        - Suscribe to `message.channels` events so your app gets notified
-    """
-    event = event_data["event"]
-    # If the incoming message contains "hi", then respond with a "Hello" message
-    if event.get("subtype") is None and 'python' in event.get('text', ''):
-        channel = event["channel"]
-        timestamp = event['ts']
-        slack_client.reactions_add(name='thumbsup', channel=channel, timestamp=timestamp)
+        slack.reactions_add(
+            name='snake',
+            channel=event["channel"],
+            timestamp=event['ts']
+        )

--- a/examples/full.py
+++ b/examples/full.py
@@ -2,13 +2,11 @@ import json
 import os
 import random
 
-from slack import WebClient
-
 from flask_slack import (ACK, OK, Flack, async_task, block_reply, request,
-                         respond, text_block)
+                         respond, text_block, Slack)
 
 app = Flack(__name__)
-cli = WebClient(os.getenv('BOT_TOKEN'))
+cli = Slack(os.getenv('BOT_TOKEN'))
 
 
 @app.command
@@ -154,3 +152,14 @@ def dice_roll():
     msg = f'🎲 {dice_value}'
     send_message(cli, blocks=[text_block(msg)], user_id=payload['user']['id'])
     return ACK
+
+
+@app.event('reaction_added')
+def echo_reaction(payload):
+    event = payload['event']
+    reaction = event['reaction']
+    cli.reactions_add(
+        name=reaction,
+        channel=event['item']['channel'],
+        timestamp=event['item']['ts']
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask==1.1.2
 slackclient==2.5.0
 requests==2.23.0
+slackeventsapi==2.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Flask==1.1.2
 slackclient==2.5.0
 requests==2.23.0
-slackeventsapi==2.1.0
+pyee

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,2 @@
+pytest
+pytest-mock

--- a/src/flask_slack/__init__.py
+++ b/src/flask_slack/__init__.py
@@ -1,13 +1,14 @@
-from .flack import Flack
-from .slack import reply, block_reply, respond, text_block, OK, ACK
-from .tasks import async_task
-
-from flask import request, jsonify
 from flask import *  # noqa: Expose all flask objects as top level imports
+from flask import jsonify, request
+from slack import WebClient as Slack
 
+from .flack import Flack
+from .slack import ACK, OK, block_reply, reply, respond, text_block
+from .tasks import async_task
 
 __all__ = [
     'Flack',
+    'Slack',
     'jsonify',
     'request',
     'reply',

--- a/src/flask_slack/dispatcher.py
+++ b/src/flask_slack/dispatcher.py
@@ -1,6 +1,5 @@
-from typing import List, Optional
+from typing import List
 from flask import request
-from dataclasses import dataclass
 import json
 
 
@@ -53,12 +52,6 @@ class Command(FormMatcher):
 
     def endpoint(self):
         return self.command
-
-
-@dataclass(eq=True, frozen=True)
-class ActionFilter:
-    action_id: str
-    block_id: Optional[str] = None
 
 
 class ActionMatcher(FormMatcher):

--- a/src/flask_slack/flack.py
+++ b/src/flask_slack/flack.py
@@ -1,7 +1,7 @@
 import logging
 
 from flask import Flask, _request_ctx_stack, request, make_response
-from pyee import BaseEventEmitter
+from pyee import ExecutorEventEmitter
 
 from .dispatcher import ActionMatcher, Command, Dispatcher, ShortcutMatcher, ViewMatcher
 
@@ -14,7 +14,7 @@ class Flack(Flask):
         super().__init__(import_name, **kwargs)
         self.dispatcher = Dispatcher()
         self.before_request_funcs.setdefault(None, []).append(self._redirect_requests)
-        self.emitter = BaseEventEmitter()
+        self.emitter = ExecutorEventEmitter()
         self._endpoint = endpoint
         self._bind_main_entrypoint(endpoint)
         self._bind_events_entrypoint(events_endpoint)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,10 @@ def bare_client():
     app = Flack('testing')
     app.config['TESTING'] = True
 
+    @app.default
+    def unknown_command():  # TODO: Review this
+        return 'Unknown Command'
+
     with app.test_client() as client:
         yield client
 
@@ -42,5 +46,9 @@ def test_app():
     @app.view('my-first-view')
     def my_view():
         return 'View'
+
+    @app.default
+    def unknown_command():
+        return 'Unknown Command'
 
     return app

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,10 +15,6 @@ def bare_client():
     app = Flack('testing')
     app.config['TESTING'] = True
 
-    @app.default
-    def unknown_command():  # TODO: Review this
-        return 'Unknown Command'
-
     with app.test_client() as client:
         yield client
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,4 +51,8 @@ def test_app():
     def unknown_command():
         return 'Unknown Command'
 
+    @app.event('reaction_added')
+    def react_to_reaction(payload):
+        return '🐍'
+
     return app

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -132,3 +132,30 @@ def test_view_decorator_captures_modal_callbacks(client):
                      content_type='application/x-www-form-urlencoded')
 
     assert b'View' == rv.data
+
+
+def test_capture_reaction_event(client, mocker):
+    payload = {
+        'event': {
+            'type': 'reaction_added',
+            'text': 'python',
+            'user': 'UG31KD90T',
+            'ts': '1588116040.001700',
+            'team': 'TG4H5ANVC',
+            'blocks': [{}],
+            'channel': 'CG34PCNRY',
+            'event_ts': '1588116040.001700',
+            'channel_type': 'channel'
+        },
+        'type': 'event_callback',
+        'event_id': 'Ev0129KEQSS3',
+    }
+    client.application.emitter = mocker.MagicMock()
+    rv = client.post('/slack/events',
+                     json=payload,
+                     content_type='application/json')
+
+    assert rv.data == b''
+    assert rv.status == '200 OK'
+    assert client.application.emitter.emit.called
+    client.application.emitter.emit.assert_called_with('reaction_added', payload)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -68,7 +68,7 @@ def test_request_handling_with_no_added_matchers(bare_client):
     rv = bare_client.post('/',
                           json={'data': {'a': 1}},
                           content_type='application/json')
-    assert b'Unknown Command' == rv.data
+    assert b'Home' == rv.data
 
 
 def test_redirect_on_action_id(client):


### PR DESCRIPTION
Add support for events callbacks. Uses pyee event emitter and threads to execute the handler on the background while to quickly return 200 to slack request.
```python
import os
from flask_slack import Flack, Slack

app = Flack(__name__)
slack = Slack(os.environ["SLACK_BOT_TOKEN"])


@app.event("message")
def handle_message(payload):
    event = payload["event"]
    if event.get("subtype") is None and 'python' in event.get('text', ''):
        slack.reactions_add(
            name='snake',
            channel=event["channel"],
            timestamp=event['ts']
        )

```